### PR TITLE
Fix Typing.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-namespace Receptacle {
+declare namespace Receptacle {
     export interface Options<T> {
         id?: number|string;
         max?: number;
@@ -31,7 +31,7 @@ namespace Receptacle {
     }
 }
 
-class Receptacle<T, X = undefined> {
+declare class Receptacle<T, X = undefined> {
     constructor(options?: Receptacle.Options<T>);
     public id: number|string;
     public max: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare class Receptacle<T, X = undefined> {
     public has(key: string): boolean;
     public get(key: string): T|null;
     public meta(key: string): X|undefined;
-    public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle;
+    public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle<T, X>;
     public delete(key: string): void;
     public expire(key: string, ms: number): void;
     public clear(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare class Receptacle<T, X = undefined> {
     public meta(key: string): X|undefined;
     public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle;
     public delete(key: string): void;
-    public expire(key: string, ms: number = 0): void;
+    public expire(key: string, ms: number): void;
     public clear(): void;
     public toJSON(): Receptacle.Export<T, X>;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "receptacle",
   "description": "In memory cache lru cache with ttl support.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": "Dylan Piercey <pierceydylan@gmail.com>",
   "bugs": "https://github.com/DylanPiercey/receptacle/issues",
   "dependencies": {


### PR DESCRIPTION
There were a few typing errors related to this declaration file:
```
leo receptacle *master $ tsc index.d.ts 
index.d.ts:1:1 - error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.

1 namespace Receptacle {
  ~~~~~~~~~

index.d.ts:43:76 - error TS2707: Generic type 'Receptacle<T, X>' requires between 1 and 2 type arguments.

43     public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle;
                                                                              ~~~~~~~~~~

index.d.ts:45:32 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

45     public expire(key: string, ms: number = 0): void;
                                  ~~~~~~~~~~~~~~


Found 3 errors.
```