### PR TITLE
Fix type declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TESTS_IN = test/*.test.js
 
 # Tools
 standard = $(BIN)/standard
+tsc = $(BIN)/tsc
 snazzy = $(BIN)/snazzy
 coveralls = $(BIN)/coveralls
 istanbul = $(BIN)/istanbul
@@ -18,6 +19,10 @@ uglifyjs = $(BIN)/uglifyjs
 # Run standard linter.
 lint:
 	$(standard) --verbose | $(snazzy)
+
+# Run type checking..
+type-check:
+	$(tsc)
 
 # Save code coverage to coveralls
 coveralls:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-namespace Receptacle {
+declare namespace Receptacle {
     export interface Options<T> {
         id?: number|string;
         max?: number;
@@ -31,7 +31,7 @@ namespace Receptacle {
     }
 }
 
-class Receptacle<T, X = undefined> {
+declare class Receptacle<T, X = undefined> {
     constructor(options?: Receptacle.Options<T>);
     public id: number|string;
     public max: number;
@@ -40,9 +40,9 @@ class Receptacle<T, X = undefined> {
     public has(key: string): boolean;
     public get(key: string): T|null;
     public meta(key: string): X|undefined;
-    public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle;
+    public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle<T, X>;
     public delete(key: string): void;
-    public expire(key: string, ms: number = 0): void;
+    public expire(key: string, ms?: number): void;
     public clear(): void;
     public toJSON(): Receptacle.Export<T, X>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2368,6 +2369,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.0.2"
       }
@@ -2475,7 +2477,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -3176,7 +3179,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "request": {
       "version": "2.87.0",
@@ -3722,6 +3726,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mocha": "^5.2.0",
     "snazzy": "^7.1.1",
     "standard": "^11.0.1",
+    "typescript": "^4.9.5",
     "uglifyjs": "^2.4.11"
   },
   "files": [
@@ -42,8 +43,9 @@
     "build": "make build",
     "coveralls": "make coveralls",
     "lint": "make lint",
-    "test": "npm run lint && make test",
-    "test-ci": "npm run lint && make test-ci"
+    "type-check": "make type-check",
+    "test": "npm run lint && npm run type-check && make test",
+    "test-ci": "npm run lint && npm run type-check && make test-ci"
   },
   "typings": "./index.d.ts",
   "standard": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "files": ["index.d.ts"]
+}


### PR DESCRIPTION
# Description

The current types in index.d.ts file are not valid typescript. Namely, they contain the following errors:

```
index.d.ts:1:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
1 namespace Receptacle {
  ~~~~~~~~~
index.d.ts:43:76 - error TS2707: Generic type 'Receptacle<T, X>' requires between 1 and 2 type arguments.
43     public set(key: string, value: T, options?: Receptacle.SetOptions<X>): Receptacle;
                                                                              ~~~~~~~~~~
index.d.ts:45:32 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
45     public expire(key: string, ms: number = 0): void;
                                  ~~~~~~~~~~~~~~
```

# Contents

In this PR:
- We fix the current typing errors
- We add a `type-check` target that ensures types are well checked for the future